### PR TITLE
Add commander extra typings and update package dependencies

### DIFF
--- a/commander.d.ts
+++ b/commander.d.ts
@@ -1,0 +1,3 @@
+declare module "commander" {
+	export * from "@commander-js/extra-typings";
+}

--- a/package.json
+++ b/package.json
@@ -26,8 +26,9 @@
 		"commander": "^14.0.1"
 	},
 	"devDependencies": {
-		"typescript": "^5.6.3",
+		"@biomejs/biome": "2.2.6",
+		"@commander-js/extra-typings": "^14.0.0",
 		"@types/node": "^22.7.5",
-		"@biomejs/biome": "2.2.6"
+		"typescript": "^5.6.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.2.6
         version: 2.2.6
+      '@commander-js/extra-typings':
+        specifier: ^14.0.0
+        version: 14.0.0(commander@14.0.1)
       '@types/node':
         specifier: ^22.7.5
         version: 22.18.11
@@ -77,6 +80,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@commander-js/extra-typings@14.0.0':
+    resolution: {integrity: sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==}
+    peerDependencies:
+      commander: ~14.0.0
+
   '@types/node@22.18.11':
     resolution: {integrity: sha512-Gd33J2XIrXurb+eT2ktze3rJAfAp9ZNjlBdh4SVgyrKEOADwCbdUDaK7QgJno8Ue4kcajscsKqu6n8OBG3hhCQ==}
 
@@ -128,6 +136,10 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.2.6':
     optional: true
+
+  '@commander-js/extra-typings@14.0.0(commander@14.0.1)':
+    dependencies:
+      commander: 14.0.1
 
   '@types/node@22.18.11':
     dependencies:

--- a/src/commands/wifi/list/command.ts
+++ b/src/commands/wifi/list/command.ts
@@ -11,9 +11,7 @@ const fieldOption = new Option("-f, --fields <FIELD...>", "Fields to display")
 	.default(["active", "ssid", "bssid", "signal", "chan"])
 	.choices(WIFI_FIELD_NAMES);
 
-listCommand.addOption(fieldOption);
-
-listCommand.action(async (options) => {
+listCommand.addOption(fieldOption).action(async (options) => {
 	const connections = await getWifiConnections(options.fields);
 
 	console.table(connections);


### PR DESCRIPTION
Introduce typings for the commander library and update related package dependencies. This change enhances type safety and ensures compatibility with the latest version of commander.

Fixes #8