### PR TITLE
Remove pull_request trigger from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: ci - Lint Code
 run-name: ${{ github.ref_name }} - Checking code of ${{ github.actor }}
 on:
   push:
-  pull_request:
 jobs:
   ci:
     name: CI - Lint Code


### PR DESCRIPTION
Eliminate the pull_request trigger from the CI workflow to streamline the process.