### PR TITLE
Update WiFi password prompt message to English

### DIFF
--- a/src/actions/wifi/connect/action.ts
+++ b/src/actions/wifi/connect/action.ts
@@ -35,7 +35,7 @@ export async function connectInteractiveAction() {
 	});
 
 	const wifiPassword = await password({
-		message: "Introduce la contraseña de la red wifi",
+		message: "Wifi password",
 		mask: "*",
 	});
 


### PR DESCRIPTION
Change the WiFi password prompt message from Spanish to English for better accessibility.